### PR TITLE
Add fix for post resolution corruption.

### DIFF
--- a/CoreObjectModel/AstsProjectedAsCodeModel/NamespaceDeclarations.cs
+++ b/CoreObjectModel/AstsProjectedAsCodeModel/NamespaceDeclarations.cs
@@ -1260,12 +1260,12 @@ namespace Microsoft.Cci.Ast {
             // This can occur at the end of a recursive chain of calls to this
             // instance method via the above call to GetMembersNamed().
             // Predecessors in the chain avoid re-adding the declaration to the
-            // namespace.
+            // namespace, and/or erroneously modifying the namespace reference.
             this.nestedUnitNamespace = nuns;
             nuns.AddNamespaceDeclaration(this);
           }
           Debug.Assert(nuns == this.nestedUnitNamespace);
-          return nuns;
+          return this.nestedUnitNamespace;
         }
       }
       NestedUnitNamespace result = this.nestedUnitNamespace = this.CreateNestedNamespace();


### PR DESCRIPTION
Ensure the namespace reference is assigned exactly once.

This should have been in #7.

This PR is a requirement for https://github.com/asnarnd/EncoreIDE/pull/118