### PR TITLE
Fix deadlock in AST namespace nodes.

### DIFF
--- a/CoreObjectModel/AstsProjectedAsCodeModel/NamespaceDeclarations.cs
+++ b/CoreObjectModel/AstsProjectedAsCodeModel/NamespaceDeclarations.cs
@@ -560,7 +560,7 @@ namespace Microsoft.Cci.Ast {
     public IEnumerable<INamespaceDeclarationMember> Members {
       get {
         if (this.cachedMembers == null)
-          lock(computeCacheLock)
+          lock(GlobalLock.LockingObject)
           {
              if (this.cachedMembers == null)
                this.cachedMembers = this.ComputeCachedMemberList();
@@ -569,7 +569,6 @@ namespace Microsoft.Cci.Ast {
       }
     }
     private IEnumerable<INamespaceDeclarationMember>/*?*/ cachedMembers;
-    private readonly object computeCacheLock = new object();
 
     /// <summary>
     /// A list of members that are either supplied as an argument during construction or later filled


### PR DESCRIPTION
An AST "project" consists of namespace declaration objects containing a read-only member list. The list can be accessed directly or via the named-entity search patterns provided by the framework. For the latter, an index is created via deferred execution under a private lock. It is possible, though not necessary, that the thread creating the index already holds the CCI GlobalLock object. It is also possible for index construction to take the GlobalLock object while iterating child AST objects. If two threads, one holding GlobalLock and one not, access the member list concurrently, deadlock is possible. This has been shown to occur in the EncoreIDE application. Remove the private lock and instead construct the index under the GlobalLock object.