### PR TITLE
Fix NullReferenceException.

### DIFF
--- a/CoreObjectModel/AstsProjectedAsCodeModel/TypeDeclarations.cs
+++ b/CoreObjectModel/AstsProjectedAsCodeModel/TypeDeclarations.cs
@@ -1180,7 +1180,8 @@ namespace Microsoft.Cci.Ast {
         BlockStatement/*?*/ outerDummyBlock = this.outerDummyBlock;
         if (outerDummyBlock == null) {
           lock (GlobalLock.LockingObject) {
-            if (this.outerDummyBlock == null) {
+            outerDummyBlock = this.outerDummyBlock;
+            if (outerDummyBlock == null) {
               this.outerDummyBlock = outerDummyBlock = BlockStatement.CreateDummyFor(this.SourceLocation);
               outerDummyBlock.SetContainers(this.ContainingNamespaceDeclaration.DummyBlock, this);
             }


### PR DESCRIPTION
This may occur in multithreaded applications when there is contention for the uninitialized value of the NamespaceTypeDeclaration .OuterDummyBlock property.