### PR TITLE
Fix embdedded resource namespaces.

### DIFF
--- a/Microsoft.Cci.Ast/Microsoft.Cci.Ast.csproj
+++ b/Microsoft.Cci.Ast/Microsoft.Cci.Ast.csproj
@@ -69,16 +69,9 @@
     </Compile>
     <EmbeddedResource Include="$(CciMetadataHelperSrcDirectory)ErrorMessages.resx">
       <Link>MetadataHelper\%(FileName)%(Extension)</Link>
-      <Generator>ResXFileCodeGenerator</Generator>
-      <CustomToolNamespace>Microsoft.Cci.MetadataHelper</CustomToolNamespace>
-      <LastGenOutput>MetadataHelper\ErrorMessages.Designer.cs</LastGenOutput>
+      <SubType>Designer</SubType>
+      <LogicalName>Microsoft.Cci.MetadataHelper.ErrorMessages</LogicalName>
     </EmbeddedResource>
-    <Compile Update="$(CciMetadataHelperSrcDirectory)ErrorMessages.Designer.cs">
-      <Link>MetadataHelper\%(FileName)%(Extension)</Link>
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-      <DependentUpon>MetadataHelper\ErrorMessages.resx</DependentUpon>
-    </Compile>
   </ItemGroup>
   
   <!-- MutableMetadataModel -->
@@ -102,16 +95,9 @@
     </Compile>
     <EmbeddedResource Include="$(CciPeReaderSrcDirectory)PeReaderErrorMessages.resx">
       <Link>PeReader\%(FileName)%(Extension)</Link>
-      <Generator>ResXFileCodeGenerator</Generator>
-      <CustomToolNamespace>Microsoft.Cci.PEReaderAndWriter.PeReader</CustomToolNamespace>
-      <LastGenOutput>PeReaderErrorMessages.Designer.cs</LastGenOutput>
+      <LogicalName>Microsoft.Cci.PeReaderErrorMessages</LogicalName>
+      <SubType>Designer</SubType>
     </EmbeddedResource>
-    <Compile Update="$(CciPeReaderSrcDirectory)PeReaderErrorMessages.Designer.cs">
-      <Link>PeReader\%(FileName)%(Extension)</Link>
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-      <DependentUpon>PeReaderErrorMessages.resx</DependentUpon>
-    </Compile>
   </ItemGroup>
 
   <!-- SourceModel -->
@@ -176,17 +162,10 @@
       <Link>AstsProjectedAsCodeModel\%(FileName)%(Extension)</Link>
     </Compile>
     <EmbeddedResource Include="$(CciAstsProjectedAsCodeModelSrcDirectory)ErrorMessages.resx">
+      <SubType>Designer</SubType>
+      <LogicalName>Microsoft.Cci.Ast.ErrorMessages.resources</LogicalName>
       <Link>AstsProjectedAsCodeModel\%(FileName)%(Extension)</Link>
-      <Generator>ResXFileCodeGenerator</Generator>
-      <CustomToolNamespace>Microsoft.Cci.Ast</CustomToolNamespace>
-      <LastGenOutput>ErrorMessages.Designer.cs</LastGenOutput>
     </EmbeddedResource>
-    <Compile Update="$(CciAstsProjectedAsCodeModelSrcDirectory)ErrorMessages.Designer.cs">
-      <Link>AstsProjectedAsCodeModel\%(FileName)%(Extension)</Link>
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-      <DependentUpon>ErrorMessages.resx</DependentUpon>
-    </Compile>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
In the unified AST project, explicitly specify the embedded resource name instead of letting the tool pick the (wrong) name based on the project folder.