### PR TITLE
Don't resolve type definition in ToString().

### DIFF
--- a/CoreObjectModel/AstsProjectedAsCodeModel/TypeDeclarations.cs
+++ b/CoreObjectModel/AstsProjectedAsCodeModel/TypeDeclarations.cs
@@ -2571,7 +2571,10 @@ namespace Microsoft.Cci.Ast {
     /// </summary>
     /// <returns></returns>
     public override string ToString() {
-      return this.Helper.GetTypeName(this.TypeDefinition);
+      // Don't evaluate TypeDefinition - when a debugger calls this before the
+      // node construction is complete, the node may be skewed or fouled.
+      //return this.Helper.GetTypeName(this.TypeDefinition);
+      return GetType().FullName;
     }
 
     /// <summary>


### PR DESCRIPTION
Because type resolution of a declaration has many side effects, and by default the VS debugger uses ToString() to display variable values, results in debugging sessions may be innacurate in comparison to runtime sessions.