### PR TITLE
Use language-specific constructor names.

### DIFF
--- a/CoreObjectModel/AstsProjectedAsCodeModel/Expressions.cs
+++ b/CoreObjectModel/AstsProjectedAsCodeModel/Expressions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -2718,6 +2718,15 @@ namespace Microsoft.Cci.Ast {
     /// <param name="sourceLocation">The source location corresponding to the newly allocated expression.</param>
     public BaseClassReference(ISourceLocation sourceLocation)
       : base(sourceLocation) {
+    }
+
+    /// <summary>
+    /// Allocates an expression that binds to the base class instance of the current object instance.
+    /// </summary>
+    /// <param name="containingBlock">A code block in the current object instance.</param>
+    /// <param name="sourceLocation">The source location corresponding to the newly allocated expression.</param>
+    public BaseClassReference(BlockStatement containingBlock, ISourceLocation sourceLocation)
+      : base(containingBlock, sourceLocation) {
     }
 
     /// <summary>

--- a/CoreObjectModel/AstsProjectedAsCodeModel/Members.cs
+++ b/CoreObjectModel/AstsProjectedAsCodeModel/Members.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -3400,7 +3400,7 @@ namespace Microsoft.Cci.Ast {
     /// </summary>
     /// <value></value>
     public bool IsConstructor {
-      get { return this.Name.Value.Equals(".ctor"); } //  TODO: Implement this properly
+      get { return !IsStatic && this.Name.UniqueKey == Declaration.CompilationPart.Compilation.NameTable.Ctor.UniqueKey; }
     }
 
     /// <summary>
@@ -3408,7 +3408,7 @@ namespace Microsoft.Cci.Ast {
     /// </summary>
     /// <value></value>
     public bool IsStaticConstructor {
-      get { return this.Name.Value.Equals(".cctor"); }  //  TODO: Implement this properly
+      get { return IsStatic && this.Name.UniqueKey == Declaration.CompilationPart.Compilation.NameTable.Cctor.UniqueKey; }
     }
 
     /// <summary>

--- a/CoreObjectModel/AstsProjectedAsCodeModel/Types.cs
+++ b/CoreObjectModel/AstsProjectedAsCodeModel/Types.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -1207,10 +1207,11 @@ namespace Microsoft.Cci.Ast {
       TypeDeclaration/*?*/ tDecl = null;
       foreach (TypeDeclaration typeDeclaration in this.TypeDeclarations) {
         if (tDecl == null) tDecl = typeDeclaration as TypeDeclaration;
+        INameTable declarationNametable = tDecl.Helper.Compilation.NameTable;
         foreach (ITypeDeclarationMember member in typeDeclaration.TypeDeclarationMembers) {
           MethodDeclaration/*?*/ method = member as MethodDeclaration;
           if (method == null) continue;
-          if (!method.IsSpecialName || method.Name.Value != ".ctor") continue;
+          if (!method.IsSpecialName || method.IsStatic || method.Name.UniqueKey != declarationNametable.Ctor.UniqueKey) continue;
           return; //There is a declared constructor
         }
       }
@@ -1323,6 +1324,7 @@ namespace Microsoft.Cci.Ast {
       List<FieldDeclaration> fieldsToIntialize = new List<FieldDeclaration>();
       foreach (TypeDeclaration typeDeclaration in this.TypeDeclarations) {
         if (tDecl == null) tDecl = typeDeclaration as TypeDeclaration;
+        INameTable declarationNametable = tDecl.Helper.Compilation.NameTable;
         foreach (ITypeDeclarationMember member in typeDeclaration.TypeDeclarationMembers) {
           FieldDeclaration/*?*/ fieldDecl = member as FieldDeclaration;
           if (fieldDecl != null && fieldDecl.IsStatic && !fieldDecl.IsCompileTimeConstant && fieldDecl.Initializer != null) {
@@ -1330,7 +1332,7 @@ namespace Microsoft.Cci.Ast {
           }
           MethodDeclaration/*?*/ method = member as MethodDeclaration;
           if (method == null) continue;
-          if (!method.IsSpecialName || method.Name.Value != ".cctor") continue;
+          if (!method.IsSpecialName || !method.IsStatic || method.Name.UniqueKey != declarationNametable.Cctor.UniqueKey) continue;
           if (IteratorHelper.EnumerableIsNotEmpty(method.Parameters)) continue;
           return; //There is a declared static constructor
         }


### PR DESCRIPTION
When determining if a method is a static or instance constructor, use the language-specific name for the constructor rather than ".cctor" and ".ctor". Also, when initializing a type declaration, look for the language-specific constructor names when determining whether or not to add default constuctors. Also, add missing constructor to support use of BaseClassReference in the AST.