### PR TITLE
Fix issues with property AST construction

### DIFF
--- a/CoreObjectModel/AstsProjectedAsCodeModel/Core.cs
+++ b/CoreObjectModel/AstsProjectedAsCodeModel/Core.cs
@@ -6883,10 +6883,9 @@ namespace Microsoft.Cci.Ast {
       this.Visit(propertyDeclaration.SourceAttributes);
       this.VisitTypeExpression(propertyDeclaration.Type);
       this.Visit(propertyDeclaration.Parameters);
-      if (propertyDeclaration.GetterBody != null)
-        this.VisitStatement(propertyDeclaration.GetterBody);
-      if (propertyDeclaration.SetterBody != null)
-        this.VisitStatement(propertyDeclaration.SetterBody);
+      foreach (MethodDeclaration accessor in propertyDeclaration.Accessors) {
+        this.Visit(accessor);
+      }
       //^ assume this.path.Count == oldCount+1; //True because all of the virtual methods of this class promise not to decrease this.path.Count.
       this.path.Pop();
     }

--- a/CoreObjectModel/AstsProjectedAsCodeModel/Expressions.cs
+++ b/CoreObjectModel/AstsProjectedAsCodeModel/Expressions.cs
@@ -16453,6 +16453,12 @@ namespace Microsoft.Cci.Ast {
       if (qualifyingType != null) {
         if (!this.ContainingBlock.ContainingTypeDeclaration.CanAccess(qualifyingType))
           resolvedQualifier = this.ResolveQualifierAsNamespace(reportError);
+        else if (this.ContainingBlock.ContainingTypeDeclaration.TypeDefinition == qualifyingType) {
+          INamespaceTypeDefinition namespaceType = qualifyingType as INamespaceTypeDefinition;
+          if (namespaceType != null) {
+            resolvedQualifier = namespaceType.ContainingNamespace;
+          }
+        }
         else {
           INestedTypeDefinition/*?*/ resolvedTypeMember = this.ResolveTypeMember(qualifyingType, false) as INestedTypeDefinition;
           if (resolvedTypeMember != null) {

--- a/CoreObjectModel/AstsProjectedAsCodeModel/MemberDeclarations.cs
+++ b/CoreObjectModel/AstsProjectedAsCodeModel/MemberDeclarations.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using Microsoft.Cci.Contracts;
 using Microsoft.Cci.Immutable;
 
@@ -2847,6 +2846,7 @@ namespace Microsoft.Cci.Ast {
           flags |= MethodDeclaration.Flags.SpecialName;
           this.getter = new MethodDeclaration(this.getterAttributes, flags, this.Visibility, typeExpr, this.implementedInterfaces, name, null, parameters, null, getterBody, this.SourceLocation);
           this.getter.SetContainingTypeDeclaration(this.ContainingTypeDeclaration, false);
+          getterBody.SetContainingBlock(this.getter.DummyBlock);
         }
         return this.getter;
       }
@@ -3117,7 +3117,7 @@ namespace Microsoft.Cci.Ast {
             foreach (ParameterDeclaration indexerParameter in this.Parameters) parameters.Add(indexerParameter);
           } else
             parameters = new List<ParameterDeclaration>(1);
-          NameDeclaration pname = new NameDeclaration(this.NameTable.value, sourceLocation);
+          NameDeclaration pname = SetterValueName;
           parameters.Add(new ParameterDeclaration(null, this.Type, pname, null, (ushort)parameters.Count, false, false, false, false, this.Type.SourceLocation));
           //TODO: worry about setter attributes defined on the property itself
           MethodDeclaration.Flags flags = (MethodDeclaration.Flags)(this.flags&0xFFFFF000);
@@ -3187,6 +3187,19 @@ namespace Microsoft.Cci.Ast {
       get { return this.PropertyDefinition; }
     }
 
+    /// <summary>
+    /// Languages that allow alternative syntax for a setter's value parameter may override this.
+    /// This implementation returns the static keyword, or null if there is no setter.
+    /// </summary>
+    public virtual NameDeclaration SetterValueName { 
+      get {
+        if (this.setterValueName == null && this.SetterBody != null) {
+          setterValueName = new NameDeclaration(this.NameTable.value, this.SetterBody.SourceLocation);
+        }
+        return setterValueName;
+      }
+    }
+    NameDeclaration setterValueName;
   }
 
   /// <summary>


### PR DESCRIPTION
Support languages that override 'value' in property setters.  Ensure that internal property declaration members are fully constructed before exposing them.