### PR TITLE
Extensions

### DIFF
--- a/CoreObjectModel/AstsProjectedAsCodeModel/Core.cs
+++ b/CoreObjectModel/AstsProjectedAsCodeModel/Core.cs
@@ -2228,21 +2228,25 @@ namespace Microsoft.Cci.Ast {
     /// <summary>
     /// Returns true if the given method can be called with the given arguments, if 
     /// need be after applying implicit conversions and constructing a parameter array, 
-    /// or a runtimeargumenthandle.
+    /// or a runtimeargumenthandle. If argumentListIsIncomplete is true only the
+    /// first n parameters of the method are considered, where n is the number of
+    /// given arguments.
     /// </summary>
     //^ [Pure]
-    public virtual bool MethodIsEligible(IMethodDefinition method, IEnumerable<Expression> arguments) {
-      return this.MethodIsEligible(method, arguments, false);
+    public virtual bool MethodIsEligible(IMethodDefinition method, IEnumerable<Expression> arguments, bool argumentListIsIncomplete) {
+      return this.MethodIsEligible(method, arguments, argumentListIsIncomplete, false);
     }
 
     /// <summary>
     /// Returns true if the given method can be called with the given arguments, if 
     /// need be after applying implicit conversions and constructing a parameter array, 
     /// or a runtimeargumenthandle. If allowTypeMismatch is true then only the number of parameters are considered
-    /// when deciding if method is eligible.
+    /// when deciding if method is eligible. If argumentListIsIncomplete is true only the
+    /// first n parameters of the method are considered, where n is the number of
+    /// given arguments.
     /// </summary>
     //^ [Pure]
-    protected virtual bool MethodIsEligible(IMethodDefinition method, IEnumerable<Expression> arguments, bool allowTypeMismatch) {
+    protected virtual bool MethodIsEligible(IMethodDefinition method, IEnumerable<Expression> arguments, bool argumentListIsIncomplete, bool allowTypeMismatch) {
       IEnumerator<IParameterDefinition> methodParameterEnumerator = method.Parameters.GetEnumerator();
       ITypeDefinition methodParamArrayElementType = Dummy.Type;
       foreach (Expression argument in arguments) {
@@ -2278,7 +2282,7 @@ namespace Microsoft.Cci.Ast {
           if (!allowTypeMismatch) return false;
         }
       }
-      if (methodParameterEnumerator.MoveNext()) return methodParameterEnumerator.Current.IsParameterArray;
+      if (methodParameterEnumerator.MoveNext()) return argumentListIsIncomplete || methodParameterEnumerator.Current.IsParameterArray;
       return true;
     }
 
@@ -2893,10 +2897,10 @@ namespace Microsoft.Cci.Ast {
       List<IMethodDefinition>/*?*/ ambiguousMatches = null;
       foreach (IMethodDefinition candidate in candidateMethods) {
         if (bestSoFar is Dummy) {
-          if (this.MethodIsEligible(candidate, arguments)) bestSoFar = candidate;
+          if (this.MethodIsEligible(candidate, arguments, false)) bestSoFar = candidate;
           continue;
         }
-        if (!this.MethodIsEligible(candidate, arguments)) {
+        if (!this.MethodIsEligible(candidate, arguments, false)) {
           continue;
         }
         if (this.Method1MatchesArgumentsBetterThanMethod2(bestSoFar, candidate, arguments)) continue;

--- a/CoreObjectModel/AstsProjectedAsCodeModel/MemberDeclarations.cs
+++ b/CoreObjectModel/AstsProjectedAsCodeModel/MemberDeclarations.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using Microsoft.Cci.Contracts;
 using Microsoft.Cci.Immutable;
 
@@ -776,6 +777,7 @@ namespace Microsoft.Cci.Ast {
     /// <summary>
     /// The number of least significant bits that form part of the value of the field.
     /// </summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public virtual uint BitLength {
       get { return TypeHelper.SizeOfType(this.Type.ResolvedType)*8; }
     }

--- a/CoreObjectModel/AstsProjectedAsCodeModel/NamespaceDeclarations.cs
+++ b/CoreObjectModel/AstsProjectedAsCodeModel/NamespaceDeclarations.cs
@@ -382,7 +382,7 @@ namespace Microsoft.Cci.Ast {
       if (candidates != null)
         // Now filter them for applicability with the given argument list
         foreach (IMethodDefinition method in candidates)
-          if (this.Helper.MethodIsEligible(method, arguments))
+          if (this.Helper.MethodIsEligible(method, arguments, false))
             result.Add(method);      
     }
 
@@ -419,7 +419,7 @@ namespace Microsoft.Cci.Ast {
       if (candidates != null)
         // Now filter the methods for applicability.
         foreach (IMethodDefinition method in candidates)
-          if (this.Helper.MethodIsEligible(method, arguments))
+          if (this.Helper.MethodIsEligible(method, arguments, false))
             result.Add(method);
     }
 


### PR DESCRIPTION
Changes to support alternative argument list matching in method call validation.  Also, add an attribute to prevent the VS debugger from crashing when evaluating a certain property.