### PR TITLE
Member type expressions

### DIFF
--- a/CoreObjectModel/AstsProjectedAsCodeModel/Expressions.cs
+++ b/CoreObjectModel/AstsProjectedAsCodeModel/Expressions.cs
@@ -1872,7 +1872,7 @@ namespace Microsoft.Cci.Ast {
 
     #region ISignatureDeclaration Members
 
-    TypeExpression ISignatureDeclaration.Type {
+    TypeExpression ITypedMemberDeclaration.Type {
       get {
         if (this.returnType == null)
           this.returnType = TypeExpression.For(this.Helper.GetInvokeMethod(this.delegateType).Type);
@@ -2034,7 +2034,7 @@ namespace Microsoft.Cci.Ast {
 
     #region ISignatureDeclaration Members
 
-    TypeExpression ISignatureDeclaration.Type {
+    TypeExpression ITypedMemberDeclaration.Type {
       get { return TypeExpression.For(Dummy.Type); }
     }
 
@@ -18104,7 +18104,12 @@ namespace Microsoft.Cci.Ast {
         this.hasErrors = null;
       return this.resolvedValue;
     }
-    object/*?*/ resolvedValue;
+
+    /// <summary>
+    /// Non null when the name has been suitably bound. Visible to derived classes so that it can be set during construction.
+    /// When non null, the item has been bound and need not be resolved again.
+    /// </summary>
+    protected object/*?*/ resolvedValue;
 
     /// <summary>
     /// Returns true if this resolves to a local declaration or a 

--- a/CoreObjectModel/AstsProjectedAsCodeModel/MemberDeclarationInterfaces.cs
+++ b/CoreObjectModel/AstsProjectedAsCodeModel/MemberDeclarationInterfaces.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
@@ -7,19 +7,23 @@ using System.Collections.Generic;
 
 namespace Microsoft.Cci.Ast {
   /// <summary>
+  /// A member declaration whose "type" is described by an expression.
+  /// </summary>
+  public interface ITypedMemberDeclaration : ISourceItem { 
+    /// <summary>
+    /// An expression that denotes the return type of a method, the type of a property, the delegate type of an event, or the stored type of a field.
+    /// </summary>
+    TypeExpression Type { get; }
+  }
+  /// <summary>
   /// The parameters and return type that makes up a method or property signature.
   /// This interface models the source representation of a signature.
   /// </summary>
-  public interface ISignatureDeclaration : ISourceItem {
+  public interface ISignatureDeclaration : ITypedMemberDeclaration {
     /// <summary>
     /// The parameters forming part of this signature.
     /// </summary>
     IEnumerable<ParameterDeclaration> Parameters { get; }
-
-    /// <summary>
-    /// An expression that denotes the return type of the method or type of the property.
-    /// </summary>
-    TypeExpression Type { get; }
 
     /// <summary>
     /// The symbol table object that represents the metadata for this signature.

--- a/CoreObjectModel/AstsProjectedAsCodeModel/MemberDeclarations.cs
+++ b/CoreObjectModel/AstsProjectedAsCodeModel/MemberDeclarations.cs
@@ -220,7 +220,7 @@ namespace Microsoft.Cci.Ast {
   /// <summary>
   /// An event is a member that enables an object or class to provide notifications. Clients can attach executable code for events by supplying event handlers.
   /// </summary>
-  public class EventDeclaration : TypeDeclarationMember {
+  public class EventDeclaration : TypeDeclarationMember, ITypedMemberDeclaration {
 
     /// <summary>
     /// Allocates an event member that enables an object or class to provide notifications. Clients can attach executable code for events by supplying event handlers.
@@ -667,7 +667,7 @@ namespace Microsoft.Cci.Ast {
   /// <summary>
   /// A field is a member that represents a variable associated with an object or class.
   /// </summary>
-  public class FieldDeclaration : TypeDeclarationMember {
+  public class FieldDeclaration : TypeDeclarationMember, ITypedMemberDeclaration {
 
     /// <summary>
     /// Allocates a member that represents a variable associated with an object or class.
@@ -1207,7 +1207,7 @@ namespace Microsoft.Cci.Ast {
   /// <summary>
   /// Represents a global variable.
   /// </summary>
-  public class GlobalFieldDeclaration : FieldDeclaration, INamespaceDeclarationMember, IAggregatableNamespaceDeclarationMember, IAggregatableTypeDeclarationMember {
+  public class GlobalFieldDeclaration : FieldDeclaration, ITypedMemberDeclaration, INamespaceDeclarationMember, IAggregatableNamespaceDeclarationMember, IAggregatableTypeDeclarationMember {
 
     /// <summary>
     /// Allocates a member that represents a variable associated with an object or class.

--- a/CoreObjectModel/AstsProjectedAsCodeModel/Members.cs
+++ b/CoreObjectModel/AstsProjectedAsCodeModel/Members.cs
@@ -1462,7 +1462,7 @@ namespace Microsoft.Cci.Ast {
             this.type = Immutable.ModifiedTypeReference.GetModifiedTypeReference(this.FieldDeclaration.Type.ResolvedType,
               IteratorHelper.GetSingletonEnumerable(volatileModifier), this.fieldDeclaration.Compilation.HostEnvironment.InternFactory);
           } else
-            this.type = this.FieldDeclaration.Type.ResolvedType;
+            return this.FieldDeclaration.Type.ResolvedType;
         }
         return this.type;
       }


### PR DESCRIPTION
Fixed bug in resolving method definitions with optional parameters.

Type expression resolutions now can be *optionally* cached by the implementation.

Generically access type expressions of all "typed" members of a declaration, via new `ITypedMemberDeclaration` interface.