### PR TITLE
Fix generic method visibility.

### DIFF
--- a/CoreObjectModel/MetadataHelper/Members.cs
+++ b/CoreObjectModel/MetadataHelper/Members.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -450,7 +450,7 @@ namespace Microsoft.Cci.Immutable {
     /// <value></value>
     public TypeMemberVisibility Visibility {
       get {
-        return TypeHelper.GenericInstanceVisibilityAsTypeMemberVisibility(this.GenericMethod.Visibility, this.GenericArguments);
+        return this.GenericMethod.Visibility;
       }
     }
 


### PR DESCRIPTION
Generic method instance visibility (public, protected, etc.) is not constrained by its generic type arguments.