### PR TITLE
Dispatch nested namespace instances.

### DIFF
--- a/CoreObjectModel/AstsProjectedAsCodeModel/Core.cs
+++ b/CoreObjectModel/AstsProjectedAsCodeModel/Core.cs
@@ -6380,7 +6380,7 @@ namespace Microsoft.Cci.Ast {
       //^ int oldCount = this.path.Count;
       NestedNamespaceDeclaration/*?*/ nestedNamespace = namespaceDeclarationMember as NestedNamespaceDeclaration;
       if (nestedNamespace != null)
-        this.Visit(nestedNamespace);
+        nestedNamespace.Dispatch(this);
       else {
         TypeDeclaration/*?*/ typeDeclaration = namespaceDeclarationMember as TypeDeclaration;
         if (typeDeclaration != null)

--- a/CoreObjectModel/AstsProjectedAsCodeModel/NamespaceDeclarations.cs
+++ b/CoreObjectModel/AstsProjectedAsCodeModel/NamespaceDeclarations.cs
@@ -1228,6 +1228,13 @@ namespace Microsoft.Cci.Ast {
     }
 
     /// <summary>
+    /// Calls the visitor.Visit(NestedNamespaceDeclaration) method.
+    /// </summary>
+    public override void Dispatch(SourceVisitor visitor) {
+      visitor.Visit(this);
+    }
+
+    /// <summary>
     /// 
     /// </summary>
     public override BlockStatement DummyBlock {


### PR DESCRIPTION
Correct a problem where nested namespaces were not completely dispatched in finders looking for certain namespace member properties.