### PR TITLE
Members without visibility cannot be accessed.

### DIFF
--- a/CoreObjectModel/MetadataHelper/TypeHelper.cs
+++ b/CoreObjectModel/MetadataHelper/TypeHelper.cs
@@ -510,6 +510,7 @@ namespace Microsoft.Cci {
       Contract.Requires(typeDefinition != null);
       Contract.Requires(member != null);
 
+      if (member.Visibility == TypeMemberVisibility.Other) return false;
       if (TypeHelper.TypesAreEquivalent(typeDefinition, member.ContainingTypeDefinition)) return true;
       if (typeDefinition.IsGeneric && TypeHelper.TypesAreEquivalent(typeDefinition.InstanceType, member.ContainingTypeDefinition))
         return true;


### PR DESCRIPTION
CanAccess utility returned positive result when passed a member with compiler-only visibility.